### PR TITLE
Fixed java hybrid row deserialization bugs

### DIFF
--- a/java/src/main/java/com/azure/data/cosmos/serialization/hybridrow/SchemaId.java
+++ b/java/src/main/java/com/azure/data/cosmos/serialization/hybridrow/SchemaId.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.ints.Int2ReferenceMap;
+import it.unimi.dsi.fastutil.ints.Int2ReferenceMaps;
 import it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap;
 
 import javax.annotation.Nonnull;
@@ -38,7 +39,7 @@ public final class SchemaId implements Comparable<SchemaId> {
     private static final Int2ReferenceMap<SchemaId> cache;
 
     static {
-        cache = new Int2ReferenceOpenHashMap<>();
+        cache = Int2ReferenceMaps.synchronize(new Int2ReferenceOpenHashMap<>());
         cache.put(0, INVALID = NONE = new SchemaId(0));
     }
 

--- a/java/src/main/java/com/azure/data/cosmos/serialization/hybridrow/layouts/SystemSchema.java
+++ b/java/src/main/java/com/azure/data/cosmos/serialization/hybridrow/layouts/SystemSchema.java
@@ -65,21 +65,12 @@ public final class SystemSchema {
     }
 
     private static InputStream getResourceAsStream(final String name) throws IOException {
+        InputStream inputStream = SystemSchema.class.getClassLoader().getResourceAsStream(name);
 
-        final CodeSource codeSource = SystemSchema.class.getProtectionDomain().getCodeSource();
-        final ClassLoader classLoader = SystemSchema.class.getClassLoader();
-        final String location = codeSource.getLocation().toString();
-        final Enumeration<URL> urls;
-
-        urls = classLoader.getResources(name);
-
-        while (urls.hasMoreElements()) {
-            final URL url = urls.nextElement();
-            if (url.getFile().endsWith(name)) {
-                return url.openStream();
-            }
+        if (inputStream != null) {
+            return inputStream;
         }
 
-        throw new FileNotFoundException(lenientFormat("cannot find %s at %s", name, location));
+        throw new FileNotFoundException(lenientFormat("cannot find %s", name));
     }
 }


### PR DESCRIPTION
This PR fixes two bugs:

* A concurrency bug due to writing concurrently to an instance Int2ReferenceOpenHashMap
* an issue in loading SystemSchema as a json

concurrency stacktrace
```bash
java.lang.ExceptionInInitializerError
	at com.azure.data.cosmos.serialization.hybridrow.layouts.Layout.<clinit>(Layout.java:43)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.LayoutBuilder.build(LayoutBuilder.java:152)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.LayoutCompiler.compile(LayoutCompiler.java:56)
	at com.azure.data.cosmos.serialization.hybridrow.schemas.Schema.compile(Schema.java:109)
	at 
...

Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
	at it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap.rehash(Int2ReferenceOpenHashMap.java:1054)
	at it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap.insert(Int2ReferenceOpenHashMap.java:272)
	at it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap.computeIfAbsent(Int2ReferenceOpenHashMap.java:480)
	at com.azure.data.cosmos.serialization.hybridrow.SchemaId.from(SchemaId.java:93)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.SystemSchema.<clinit>(SystemSchema.java:39)
	... 41 more
```

second issue stacktrace:
```
Caused by: java.lang.IllegalStateException: failed to initialize java.io.FileNotFoundException: cannot find resource at code source location file:/databricks/spark/work/app-20191114030838-0000/1/./addedFile44638633476376558714781df4a_b380_4e69_8b69_d918777f6c9e_cosmos_analytics_spark_connector_assembly_1_2_1_SNAPSHOT_33908-70216.jar due to %s
	at com.azure.data.cosmos.serialization.hybridrow.layouts.SystemSchema.lambda$static$1(SystemSchema.java:49)
	at shaded.com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:167)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.SystemSchema.layoutResolver(SystemSchema.java:62)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.Layout.<clinit>(Layout.java:43)
	... 40 more
Caused by: java.io.FileNotFoundException: cannot find resource at code source location file:/databricks/spark/work/app-20191114030838-0000/1/./addedFile44638633476376558714781df4a_b380_4e69_8b69_d918777f6c9e_cosmos_analytics_spark_connector_assembly_1_2_1_SNAPSHOT_33908-70216.jar
	at com.azure.data.cosmos.serialization.hybridrow.layouts.SystemSchema.getResourceAsStream(SystemSchema.java:81)
	at com.azure.data.cosmos.serialization.hybridrow.layouts.SystemSchema.lambda$static$1(SystemSchema.java:45)
	... 43 more
```